### PR TITLE
Corrected wrong argument for last bit of generator polynomial being 1

### DIFF
--- a/docs/btech/cs/computer_networks/ll.md
+++ b/docs/btech/cs/computer_networks/ll.md
@@ -228,7 +228,7 @@ produce a different result. The error can then be detected.
 ![CRC Calculation](../../../assets/btech/cs/computer_networks/ll6.png)
 *Figure: [Tanenbaum] Example Calculation of CRC*
 
-* Note that we require that lower order bit is 1 as o/w $x^rM(x)$ is already divisible by $G(x)$.
+* Note that we require that lower order bit be 1 for G(x). If not the CRC checksum calculated for any M(x) will always have 0 in as its last bit and thus would not contribute to error detection in the final (message + checksum). 
 * $x^rM(x)$ instead of $M(x)$ as o/w we will be modifying the message itself.
 * Interestingly, no polynomial with an odd number of terms has x + 1 as a factor in the modulo 2 system. Proof [here](https://www.computing.dcu.ie/~humphrys/Notes/Networks/data.polynomial.html).
 * What about burst errors? A burst error of length $k$ can be represented by $x^i (x^{k−1} + · · · + 1)$. Can detect burst errors of length $≤ r$ , where $r$ is the degree of $G (x)$.


### PR DESCRIPTION
Counter example of last argument - M(x) = 1011, G(x) = 110